### PR TITLE
add back GCM cipher

### DIFF
--- a/lib/puppet/parser/functions/get_ssh_ciphers.rb
+++ b/lib/puppet/parser/functions/get_ssh_ciphers.rb
@@ -26,7 +26,7 @@ Puppet::Parser::Functions.newfunction(:get_ssh_ciphers, :type => :rvalue) do |ar
   ciphers_53['weak'] = ciphers_53['default'] + ',aes256-cbc,aes192-cbc,aes128-cbc'
 
   ciphers_66 = {}
-  ciphers_66.default = 'chacha20-poly1305@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
+  ciphers_66.default = 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
   ciphers_66['weak'] = ciphers_66['default'] + ',aes256-cbc,aes192-cbc,aes128-cbc'
 
   # creat the default version map (if os + version are default)


### PR DESCRIPTION
we originally removed GCM from the cipher chain due to vulnerabilities in OpenSSH. We are adding it back, since any sensible implementation will have had enough time to fix or backport. On top of that, GCM is generally a preferred algorithm. Let's get it back now.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>