### PR TITLE
remove sha1 key-exchange mechanisms from default

### DIFF
--- a/lib/puppet/parser/functions/get_ssh_kex.rb
+++ b/lib/puppet/parser/functions/get_ssh_kex.rb
@@ -22,12 +22,12 @@ Puppet::Parser::Functions.newfunction(:get_ssh_kex, :type => :rvalue) do |args|
   weak_kex = args[2] ? 'weak' : 'default'
 
   kex_59 = {}
-  kex_59.default = 'diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1'
-  kex_59['weak'] = kex_59['default'] + ',diffie-hellman-group1-sha1'
+  kex_59.default = 'diffie-hellman-group-exchange-sha256'
+  kex_59['weak'] = kex_59['default'] + ',diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1'
 
   kex_66 = {}
-  kex_66.default = 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1'
-  kex_66['weak'] = kex_66['default'] + ',diffie-hellman-group1-sha1'
+  kex_66.default = 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'
+  kex_66['weak'] = kex_66['default'] + ',diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1'
 
   # creat the default version map (if os + version are default)
   default_vmap = {}

--- a/spec/functions/get_ssh_kex_spec.rb
+++ b/spec/functions/get_ssh_kex_spec.rb
@@ -26,7 +26,7 @@ describe 'get_ssh_kex' do
   end
 
   it 'should get the correct kex (default)' do
-    scope.function_get_ssh_kex(['', '', false]).should eq('diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1')
+    scope.function_get_ssh_kex(['', '', false]).should eq('diffie-hellman-group-exchange-sha256')
   end
 
   it 'should get the correct kex (default weak)' do
@@ -34,7 +34,7 @@ describe 'get_ssh_kex' do
   end
 
   it 'should get the correct kex (ubuntu 12.04, default)' do
-    scope.function_get_ssh_kex(['ubuntu', '12.04', false]).should eq('diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1')
+    scope.function_get_ssh_kex(['ubuntu', '12.04', false]).should eq('diffie-hellman-group-exchange-sha256')
   end
 
   it 'should get the correct kex (ubuntu 12.04, weak)' do


### PR DESCRIPTION
Move diffie-hellman-group14-sha1 and diffie-hellman-group-exchange-sha1 to 'weak' KEX mechanisms.

References:
* https://stribika.github.io/2015/01/04/secure-secure-shell.html
* https://github.com/TelekomLabs/chef-ssh-hardening/issues/64

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>