### PR TITLE
UsePrivilegeSeparation = sandbox for ssh >= 5.9

### DIFF
--- a/lib/puppet/parser/functions/use_privilege_separation.rb
+++ b/lib/puppet/parser/functions/use_privilege_separation.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+#
+# Copyright 2015, Dominik Richter
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Puppet::Parser::Functions.newfunction(:use_privilege_separation, :type => :rvalue) do |args|
+  os = args[0].downcase
+  osrelease = args[1]
+  osmajor = osrelease.sub(/\..*/, '')
+
+  ps53 = 'yes'
+  ps59 = 'sandbox'
+  ps = ps59
+
+  # redhat/centos/oracle 6.x has ssh 5.3
+  if os == 'redhat' || os == 'centos' || os == 'oraclelinux'
+    ps = ps53
+
+  # debian 7.x and newer has ssh 5.9+
+  elsif os == 'debian' && osmajor.to_i <= 6
+    ps = ps53
+  end
+
+  ps
+end

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -76,6 +76,7 @@ class ssh_hardening::server (
   $ciphers = get_ssh_ciphers($::operatingsystem, $::operatingsystemrelease, $cbc_required)
   $macs = get_ssh_macs($::operatingsystem, $::operatingsystemrelease, $weak_hmac)
   $kex = get_ssh_kex($::operatingsystem, $::operatingsystemrelease, $weak_kex)
+  $priv_sep = use_privilege_separation($::operatingsystem, $::operatingsystemrelease)
 
   $permit_root_login = $allow_root_with_key ? {
     true  => 'without-password',
@@ -169,7 +170,7 @@ class ssh_hardening::server (
 
       # Secure Login directives.
       'UseLogin'                        => 'no',
-      'UsePrivilegeSeparation'          => 'sandbox',
+      'UsePrivilegeSeparation'          => $priv_sep,
       'PermitUserEnvironment'           => 'no',
       'LoginGraceTime'                  => '30s',
       'MaxAuthTries'                    => 2,

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -25,11 +25,11 @@ describe 'ssh_hardening::server' do
 
   it do
     should contain_file('/etc/ssh').with(
-                                           'ensure' => 'directory',
-                                           'owner' => 'root',
-                                           'group' => 'root',
-                                           'mode' => '0755'
-                                         )
+      'ensure' => 'directory',
+      'owner' => 'root',
+      'group' => 'root',
+      'mode' => '0755'
+    )
   end
 
   it { should contain_class('ssh::server').with_storeconfigs_enabled(false) }


### PR DESCRIPTION
Add OS-detection on top of: https://github.com/TelekomLabs/puppet-ssh-hardening/pull/42

See tests: https://github.com/TelekomLabs/tests-ssh-hardening/pull/44

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>